### PR TITLE
Add enabled flag check when changing tab type

### DIFF
--- a/background.js
+++ b/background.js
@@ -25,7 +25,7 @@ chrome.runtime.onMessage.addListener((request) => {
     chrome.storage.sync.set({ tabType: tabType })
 
     // If Ultimate Guitar tab is open, re-run the search with the new tab type
-    if (lastSongTitle !== '') {
+    if (enabled && lastSongTitle !== '') {
       searchSongOnUltimateGuitar(lastSongTitle)
     }
   }


### PR DESCRIPTION
## Summary
- guard tab type searches with `enabled` flag to avoid unwanted Ultimate Guitar tabs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68441fdbd6708333833493544551d0d4